### PR TITLE
カーソル実装

### DIFF
--- a/Source/Actors/UI/SceneChangeButton.cpp
+++ b/Source/Actors/UI/SceneChangeButton.cpp
@@ -39,6 +39,7 @@ namespace SceneChangeButton
 		SetEnterButton(XI::VGP::B1);
 		SetRecieveInputEnable(true);
 		SetSelected(false);
+		SetMouse(ge->mouse);
 		
 		//★タスクの生成
 
@@ -61,9 +62,6 @@ namespace SceneChangeButton
 	//「更新」１フレーム毎に行う処理
 	void  Object::UpDate()
 	{
-		auto mouse = ge->mouse->GetState();
-		SetSelected(box_->CheckHit(ML::Box2D(mouse.pos.x, mouse.pos.y, 1, 1)));
-
 		ToggleButton::UpDate();
 	}
 	//-------------------------------------------------------------------

--- a/Source/Actors/UI/SceneChangeButton.h
+++ b/Source/Actors/UI/SceneChangeButton.h
@@ -10,7 +10,7 @@ namespace SceneChangeButton
 {
 	//タスクに割り当てるグループ名と固有名
 	const  string  defGroupName("UI");					//グループ名
-	const  string  defName("SceneChangeButton");		//タスク名
+	const  string  defName("Button");					//タスク名
 	//-------------------------------------------------------------------
 	class  Resource : public BResource
 	{

--- a/Source/Actors/UI/Task_Cursor.h
+++ b/Source/Actors/UI/Task_Cursor.h
@@ -5,6 +5,8 @@
 //-------------------------------------------------------------------
 #include "../../../Actor.h"
 
+class Movement;
+
 namespace Cursor
 {
 	//タスクに割り当てるグループ名と固有名
@@ -22,8 +24,8 @@ namespace Cursor
 		typedef  weak_ptr<Resource>		WP;
 		static   WP  instance;
 		static  Resource::SP  Create();
-	//変更可◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇
-		//共有する変数はここに追加する
+
+		DG::Image::SP image_;
 	};
 	//-------------------------------------------------------------------
 	class  Object : public  Actor
@@ -45,9 +47,12 @@ namespace Cursor
 		void  UpDate()		override;	//「実行」１フレーム毎に行う処理
 		void  Render2D_AF()	override;	//「2D描画」１フレーム毎に行う処理
 		bool  Finalize();		//「終了」タスク消滅時に１回だけ行う処理
+
+		shared_ptr<Movement> movement_;
+
+		XI::VGP enterButton_;
 	public:
-	//変更可◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇◇
-		//追加したい変数・メソッドはここに追加する
-		//BCharaに含まれないモノのみここに追加する
+		void SetEnterButton(const XI::VGP enterButton);
+		XI::VGP GetEnterButton() const;
 	};
 }

--- a/ToggleButton.cpp
+++ b/ToggleButton.cpp
@@ -1,10 +1,13 @@
 #include "ToggleButton.h"
 
+#include "Source/Actors/UI/Task_Cursor.h"
+
 ToggleButton::ToggleButton()
 	:
 	buttonState_(0),
 	text_(""),
-	enterButton_()
+	enterButton_(),
+	mouseEnterButton_()
 {
 }
 
@@ -25,6 +28,23 @@ void ToggleButton::ToggleEvent()
 		OnEvent();
 	else
 		OffEvent();
+}
+
+bool ToggleButton::CanSelectedIsOn()
+{
+	//マウス
+	const ML::Point& mousePos = mouse_.lock()->GetState().pos;
+	if (CheckHit(ML::Box2D(mousePos.x, mousePos.y, 1, 1)))
+		return true;
+
+	//選択状態を変更するアクター(カーソル等)
+	for (auto& selector : selectors_)
+	{
+		if (selector->CheckHit(box_->getHitBase().OffsetCopy(pos_)))
+			return true;
+	}
+
+	return false;
 }
 
 void ToggleButton::Reset()
@@ -112,8 +132,19 @@ void ToggleButton::Drawtext(const DG::Font::SP& font, const bool drawState)
 	font->Draw(ML::Box2D(pos_.x, pos_.y, 600, 600), msg, ML::Color(1.0f, 1.0f, 0.0f, 0.0f));
 }
 
+void ToggleButton::SetMouse(const shared_ptr<XI::Mouse> mouse)
+{
+	mouse_ = mouse;
+}
+void ToggleButton::SetSelector(const Actor* selector)
+{
+	selectors_.push_back(selector);
+}
+
 void ToggleButton::UpDate()
 {
+	SetSelected(CanSelectedIsOn());
+
 	SetStateText();
 
 	if (GetButtonState((int)ButtonState::IsSelected | (int)ButtonState::RecieveInput)) 

--- a/ToggleButton.h
+++ b/ToggleButton.h
@@ -16,12 +16,17 @@ class ToggleButton : public Actor
 	string text_;
 	string stateText_;
 
+	weak_ptr<XI::Mouse> mouse_;
+	vector<const Actor*> selectors_;
+
 	void SetButtonState(const int bit, const bool flag);
 	bool GetButtonState(const int bit) const;
 
 	void SetStateText();
 
 	void ToggleEvent();
+
+	bool CanSelectedIsOn();
 public:
 	ToggleButton();
 	virtual ~ToggleButton() {};
@@ -43,6 +48,8 @@ public:
 	void SetEnterButton(const XI::Mouse::MB enterButton);
 	void SetText(const string& text);
 	void Drawtext(const DG::Font::SP& font, const bool drawState);
+	void SetMouse(const shared_ptr<XI::Mouse> mouse);
+	void SetSelector(const Actor* selector);
 
 	void UpDate() override;
 };


### PR DESCRIPTION
マウスと同時に当たり判定可能
マウス、カーソル両方が別々のボタンに重なっていた時の優先順位等はまだ設定してない　マウスが動いたときにカーソルを非表示とかにした方がいいかも？