### PR TITLE
ゲームシーンから拠点に戻ったときに、タスクが正常にキルされないバグを修正

### DIFF
--- a/Source/Scene/GameScene.cpp
+++ b/Source/Scene/GameScene.cpp
@@ -22,6 +22,7 @@
 #include "../Actors/Task_Player.h"
 #include "../../Camera.h"
 #include "../System/Task_Save.h"
+#include "../Actors/Enemys/Task_BlondeLady.h"
 
 namespace  GameScene
 {
@@ -136,11 +137,10 @@ namespace  GameScene
 	{
 		//★データ＆タスク解放
 
-		ge->KillAll_G("本編");
-		ge->KillAll_G("システム");
+		ge->KillAll_G(Map::defGroupName);
+		ge->KillAll_G(BackGround::defGroupName);
 		ge->KillAll_G(SceneChangeButton::defGroupName);
-		ge->KillAll_G("キャラクタ");
-		ge->KillAll_G("敵");
+		ge->KillAll_G(BlondeLady::defGroupName);
 
 		ge->debugRectReset();
 


### PR DESCRIPTION
GitHubからの競合解決によって文字コードが変更されたためタスクネームが正常に読み取れずキルされなかった