### PR TITLE
ゲームオーバー条件を設定できるように変更

### DIFF
--- a/GPG_2020.vcxproj.filters
+++ b/GPG_2020.vcxproj.filters
@@ -426,6 +426,9 @@
     <ClCompile Include="Source\Actors\Task_LongSword.cpp">
       <Filter>MyPG\Task\Actors</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Components\GameOverEventComponent.cpp">
+      <Filter>MyPG\Components</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameEngine_Ver3_83.h">
@@ -771,6 +774,9 @@
     </ClInclude>
     <ClInclude Include="Source\Actors\Task_LongSword.h">
       <Filter>MyPG\Task\Actors</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Components\GameOverEventComponent.h">
+      <Filter>MyPG\Components</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Components/GameOverEventComponent.cpp
+++ b/Source/Components/GameOverEventComponent.cpp
@@ -17,7 +17,8 @@ GameOverEventComponent::GameOverEventComponent(Scene* owner, const std::string& 
 	Component((Actor*)owner),
 	gameOver_(false),
 	eventPath_(eventPath),
-	waitTimer_(make_shared<SecondsTimerComponent>(owner))
+	waitTimer_(make_shared<SecondsTimerComponent>(owner)),
+	predicate_(nullptr)
 {
 	waitTimer_->SetCountSeconds(waitTime);
 }
@@ -26,7 +27,11 @@ void GameOverEventComponent::Update()
 {
 	waitTimer_->Update();
 
-	CheckGameOver();
+	if (predicate_ == nullptr)
+		assert(!"ゲームオーバー条件が設定されていません。");
+	gameOver_ = predicate_();
+
+	//CheckGameOver();
 	if (gameOver_)
 		ReadyGameOverEvent();
 
@@ -45,14 +50,18 @@ void GameOverEventComponent::SetEventPath(const std::string& eventPath)
 {
 	eventPath_ = eventPath;
 }
-
-void GameOverEventComponent::CheckGameOver()
+void GameOverEventComponent::SetPred(const std::function<bool(void)>& predicate)
 {
-	if (ge->playerPtr->GetStatus()->HP.IsAlive())
-		return;
-
-	gameOver_ = true;
+	predicate_ = predicate;
 }
+
+//void GameOverEventComponent::CheckGameOver()
+//{
+//	if (ge->playerPtr->GetStatus()->HP.IsAlive())
+//		return;
+//
+//	gameOver_ = true;
+//}
 
 void GameOverEventComponent::ReadyGameOverEvent()
 {

--- a/Source/Components/GameOverEventComponent.h
+++ b/Source/Components/GameOverEventComponent.h
@@ -2,6 +2,7 @@
 #include "../../Component.h"
 #include <string>
 #include <memory>
+#include <functional>
 
 namespace EventEngine { class Object; }
 
@@ -11,6 +12,7 @@ class GameOverEventComponent : public Component
 	std::string eventPath_;
 	std::shared_ptr<class SecondsTimerComponent> waitTimer_;
 	std::weak_ptr<EventEngine::Object> event_;
+	std::function<bool(void)> predicate_;
 
 public:
 	GameOverEventComponent(class Scene* owner, const std::string& eventPath);
@@ -20,6 +22,7 @@ public:
 
 	void SetWaitTime(const float time);
 	void SetEventPath(const std::string& eventPath);
+	void SetPred(const std::function<bool(void)>& predicate);
 
 	void CheckGameOver();
 	void ReadyGameOverEvent();

--- a/Source/Scene/GameScene.cpp
+++ b/Source/Scene/GameScene.cpp
@@ -79,6 +79,16 @@ namespace  GameScene
 										this,
 										"./data/event/eventgamestart.txt",//ここでゲームオーバー時のイベントを設定
 										0.8f));
+		gameOverEvent_->SetPred(
+			function<bool(void)>
+			(
+				[this]()
+				{
+					return !ge->playerPtr->GetStatus()->HP.IsAlive() ||
+						limitTimer_->WasCountEnd();
+				}
+			)
+		);
 
 		auto save = Save::Object::Create(true);
 

--- a/Source/Scene/MartialFightScene.cpp
+++ b/Source/Scene/MartialFightScene.cpp
@@ -102,6 +102,15 @@ namespace MartialFightScene
 										this,
 										"./data/event/eventmartialfightclear.txt",//ここでゲームオーバー時のイベントを変更
 										0.8f));
+		gameOverEvent_->SetPred(
+			function<bool(void)>
+			(
+				[]()
+				{
+					return !ge->playerPtr->GetStatus()->HP.IsAlive();
+				}
+			)
+		);
 
 		//AddComponent(debugTimer = make_shared<SecondsTimerComponent>(this));
 		//debugTimer->SetCountSeconds(0.3f);


### PR DESCRIPTION
採掘場のゲームオーバー条件を  プレイヤの死亡 または 時間切れ  に変更